### PR TITLE
chore: add Renovate presets for

### DIFF
--- a/.github/renovate-presets/workspace/rhdh-mcp-integrations-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-mcp-integrations-presets.json
@@ -1,0 +1,28 @@
+{
+  "packageRules": [
+    {
+      "description": "all Mcp Integrations minor updates",
+      "matchFileNames": ["workspaces/mcp-integrations/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(Mcp Integrations)"
+      ],
+      "addLabels": ["team/rhdh", "mcp-integrations"]
+    },
+    {
+      "description": "all Mcp Integrations patch updates",
+      "matchFileNames": ["workspaces/mcp-integrations/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(Mcp Integrations)"
+      ],
+      "addLabels": ["team/rhdh", "mcp-integrations"]
+    },
+    {
+      "description": "all Mcp Integrations dev dependency updates",
+      "matchFileNames": ["workspaces/mcp-integrations/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(Mcp Integrations)"
+      ],
+      "addLabels": ["team/rhdh", "mcp-integrations"]
+    }
+  ]
+}

--- a/.github/renovate-presets/workspace/rhdh-noop-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-noop-presets.json
@@ -1,0 +1,28 @@
+{
+  "packageRules": [
+    {
+      "description": "all Noop minor updates",
+      "matchFileNames": ["workspaces/noop/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(Noop)"
+      ],
+      "addLabels": ["team/rhdh", "noop"]
+    },
+    {
+      "description": "all Noop patch updates",
+      "matchFileNames": ["workspaces/noop/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(Noop)"
+      ],
+      "addLabels": ["team/rhdh", "noop"]
+    },
+    {
+      "description": "all Noop dev dependency updates",
+      "matchFileNames": ["workspaces/noop/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(Noop)"
+      ],
+      "addLabels": ["team/rhdh", "noop"]
+    }
+  ]
+}

--- a/.github/renovate-presets/workspace/rhdh-repo-tools-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-repo-tools-presets.json
@@ -1,0 +1,28 @@
+{
+  "packageRules": [
+    {
+      "description": "all Repo Tools minor updates",
+      "matchFileNames": ["workspaces/repo-tools/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(Repo Tools)"
+      ],
+      "addLabels": ["team/rhdh", "repo-tools"]
+    },
+    {
+      "description": "all Repo Tools patch updates",
+      "matchFileNames": ["workspaces/repo-tools/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(Repo Tools)"
+      ],
+      "addLabels": ["team/rhdh", "repo-tools"]
+    },
+    {
+      "description": "all Repo Tools dev dependency updates",
+      "matchFileNames": ["workspaces/repo-tools/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(Repo Tools)"
+      ],
+      "addLabels": ["team/rhdh", "repo-tools"]
+    }
+  ]
+}

--- a/.github/renovate-presets/workspace/rhdh-scorecard-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-scorecard-presets.json
@@ -1,0 +1,28 @@
+{
+  "packageRules": [
+    {
+      "description": "all Scorecard minor updates",
+      "matchFileNames": ["workspaces/scorecard/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(Scorecard)"
+      ],
+      "addLabels": ["team/rhdh", "scorecard"]
+    },
+    {
+      "description": "all Scorecard patch updates",
+      "matchFileNames": ["workspaces/scorecard/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(Scorecard)"
+      ],
+      "addLabels": ["team/rhdh", "scorecard"]
+    },
+    {
+      "description": "all Scorecard dev dependency updates",
+      "matchFileNames": ["workspaces/scorecard/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(Scorecard)"
+      ],
+      "addLabels": ["team/rhdh", "scorecard"]
+    }
+  ]
+}

--- a/.github/renovate-presets/workspace/rhdh-translations-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-translations-presets.json
@@ -1,0 +1,28 @@
+{
+  "packageRules": [
+    {
+      "description": "all Translations minor updates",
+      "matchFileNames": ["workspaces/translations/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(Translations)"
+      ],
+      "addLabels": ["team/rhdh", "translations"]
+    },
+    {
+      "description": "all Translations patch updates",
+      "matchFileNames": ["workspaces/translations/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(Translations)"
+      ],
+      "addLabels": ["team/rhdh", "translations"]
+    },
+    {
+      "description": "all Translations dev dependency updates",
+      "matchFileNames": ["workspaces/translations/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(Translations)"
+      ],
+      "addLabels": ["team/rhdh", "translations"]
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,29 +20,13 @@
     "enabled": false,
     "labels": ["dependencies", "security"]
   },
-  "npm": {
-    "minimumReleaseAge": "3 days"
-  },
-  "major": {
-    "dependencyDashboardApproval": true
-  },
+  "npm": { "minimumReleaseAge": "3 days" },
+  "major": { "dependencyDashboardApproval": true },
   "packageRules": [
-    {
-      "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions"
-    },
-    {
-      "matchPackageNames": ["node-fetch"],
-      "allowedVersions": "<3.0.0"
-    },
-    {
-      "matchPackageNames": ["typescript"],
-      "allowedVersions": "~5.3.0"
-    },
-    {
-      "matchPackageNames": ["yn"],
-      "allowedVersions": "<5.0.0"
-    },
+    { "matchManagers": ["github-actions"], "groupName": "GitHub Actions" },
+    { "matchPackageNames": ["node-fetch"], "allowedVersions": "<3.0.0" },
+    { "matchPackageNames": ["typescript"], "allowedVersions": "~5.3.0" },
+    { "matchPackageNames": ["yn"], "allowedVersions": "<5.0.0" },
     {
       "description": "all RHDH Plugins workspaces",
       "extends": [
@@ -57,7 +41,12 @@
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-sandbox-presets",
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-openshift-image-registry-presets",
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-redhat-resource-optimization-presets",
-        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-quickstart-presets"
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-quickstart-presets",
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-mcp-integrations-presets",
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-noop-presets",
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-repo-tools-presets",
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-scorecard-presets",
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-translations-presets"
       ]
     },
     {


### PR DESCRIPTION
This PR adds Renovate presets for the new `` workspace.

Extends: base minor/patch/devdependency presets.

Created by [Detect New Workspace 18294662588](https://github.com/JessicaJHee/rhdh-plugins/actions/runs/18294662588)