### PR TITLE
chore: add Renovate presets for repo-tools

### DIFF
--- a/.github/renovate-presets/workspace/rhdh-repo-tools-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-repo-tools-presets.json
@@ -1,0 +1,28 @@
+{
+  "packageRules": [
+    {
+      "description": "all Repo Tools minor updates",
+      "matchFileNames": ["workspaces/repo-tools/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(Repo Tools)"
+      ],
+      "addLabels": ["team/rhdh", "repo-tools"]
+    },
+    {
+      "description": "all Repo Tools patch updates",
+      "matchFileNames": ["workspaces/repo-tools/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(Repo Tools)"
+      ],
+      "addLabels": ["team/rhdh", "repo-tools"]
+    },
+    {
+      "description": "all Repo Tools dev dependency updates",
+      "matchFileNames": ["workspaces/repo-tools/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(Repo Tools)"
+      ],
+      "addLabels": ["team/rhdh", "repo-tools"]
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,29 +20,13 @@
     "enabled": false,
     "labels": ["dependencies", "security"]
   },
-  "npm": {
-    "minimumReleaseAge": "3 days"
-  },
-  "major": {
-    "dependencyDashboardApproval": true
-  },
+  "npm": { "minimumReleaseAge": "3 days" },
+  "major": { "dependencyDashboardApproval": true },
   "packageRules": [
-    {
-      "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions"
-    },
-    {
-      "matchPackageNames": ["node-fetch"],
-      "allowedVersions": "<3.0.0"
-    },
-    {
-      "matchPackageNames": ["typescript"],
-      "allowedVersions": "~5.3.0"
-    },
-    {
-      "matchPackageNames": ["yn"],
-      "allowedVersions": "<5.0.0"
-    },
+    { "matchManagers": ["github-actions"], "groupName": "GitHub Actions" },
+    { "matchPackageNames": ["node-fetch"], "allowedVersions": "<3.0.0" },
+    { "matchPackageNames": ["typescript"], "allowedVersions": "~5.3.0" },
+    { "matchPackageNames": ["yn"], "allowedVersions": "<5.0.0" },
     {
       "description": "all RHDH Plugins workspaces",
       "extends": [
@@ -57,7 +41,8 @@
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-sandbox-presets",
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-openshift-image-registry-presets",
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-redhat-resource-optimization-presets",
-        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-quickstart-presets"
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-quickstart-presets",
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-repo-tools-presets"
       ]
     },
     {


### PR DESCRIPTION
This PR adds Renovate presets for the new `repo-tools` workspace.

Extends: base minor/patch/devdependency presets.

Created by [Detect New Workspace 18295428523](https://github.com/JessicaJHee/rhdh-plugins/actions/runs/18295428523)