### PR TITLE
chore: add Renovate presets for scorecard

### DIFF
--- a/.github/renovate-presets/workspace/rhdh-scorecard-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-scorecard-presets.json
@@ -1,0 +1,28 @@
+{
+  "packageRules": [
+    {
+      "description": "all Scorecard minor updates",
+      "matchFileNames": ["workspaces/scorecard/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(Scorecard)"
+      ],
+      "addLabels": ["team/rhdh", "scorecard"]
+    },
+    {
+      "description": "all Scorecard patch updates",
+      "matchFileNames": ["workspaces/scorecard/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(Scorecard)"
+      ],
+      "addLabels": ["team/rhdh", "scorecard"]
+    },
+    {
+      "description": "all Scorecard dev dependency updates",
+      "matchFileNames": ["workspaces/scorecard/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(Scorecard)"
+      ],
+      "addLabels": ["team/rhdh", "scorecard"]
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,29 +20,13 @@
     "enabled": false,
     "labels": ["dependencies", "security"]
   },
-  "npm": {
-    "minimumReleaseAge": "3 days"
-  },
-  "major": {
-    "dependencyDashboardApproval": true
-  },
+  "npm": { "minimumReleaseAge": "3 days" },
+  "major": { "dependencyDashboardApproval": true },
   "packageRules": [
-    {
-      "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions"
-    },
-    {
-      "matchPackageNames": ["node-fetch"],
-      "allowedVersions": "<3.0.0"
-    },
-    {
-      "matchPackageNames": ["typescript"],
-      "allowedVersions": "~5.3.0"
-    },
-    {
-      "matchPackageNames": ["yn"],
-      "allowedVersions": "<5.0.0"
-    },
+    { "matchManagers": ["github-actions"], "groupName": "GitHub Actions" },
+    { "matchPackageNames": ["node-fetch"], "allowedVersions": "<3.0.0" },
+    { "matchPackageNames": ["typescript"], "allowedVersions": "~5.3.0" },
+    { "matchPackageNames": ["yn"], "allowedVersions": "<5.0.0" },
     {
       "description": "all RHDH Plugins workspaces",
       "extends": [
@@ -57,7 +41,8 @@
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-sandbox-presets",
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-openshift-image-registry-presets",
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-redhat-resource-optimization-presets",
-        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-quickstart-presets"
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-quickstart-presets",
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-scorecard-presets"
       ]
     },
     {


### PR DESCRIPTION
This PR adds Renovate presets for the new `scorecard` workspace.

Extends: base minor/patch/devdependency presets.

Created by [Detect New Workspace 18295428523](https://github.com/JessicaJHee/rhdh-plugins/actions/runs/18295428523)