### PR TITLE
chore: add Renovate presets for mcp-integrations

### DIFF
--- a/.github/renovate-presets/workspace/rhdh-mcp-integrations-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-mcp-integrations-presets.json
@@ -1,0 +1,28 @@
+{
+  "packageRules": [
+    {
+      "description": "all Mcp Integrations minor updates",
+      "matchFileNames": ["workspaces/mcp-integrations/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(Mcp Integrations)"
+      ],
+      "addLabels": ["team/rhdh", "mcp-integrations"]
+    },
+    {
+      "description": "all Mcp Integrations patch updates",
+      "matchFileNames": ["workspaces/mcp-integrations/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(Mcp Integrations)"
+      ],
+      "addLabels": ["team/rhdh", "mcp-integrations"]
+    },
+    {
+      "description": "all Mcp Integrations dev dependency updates",
+      "matchFileNames": ["workspaces/mcp-integrations/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(Mcp Integrations)"
+      ],
+      "addLabels": ["team/rhdh", "mcp-integrations"]
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,29 +20,13 @@
     "enabled": false,
     "labels": ["dependencies", "security"]
   },
-  "npm": {
-    "minimumReleaseAge": "3 days"
-  },
-  "major": {
-    "dependencyDashboardApproval": true
-  },
+  "npm": { "minimumReleaseAge": "3 days" },
+  "major": { "dependencyDashboardApproval": true },
   "packageRules": [
-    {
-      "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions"
-    },
-    {
-      "matchPackageNames": ["node-fetch"],
-      "allowedVersions": "<3.0.0"
-    },
-    {
-      "matchPackageNames": ["typescript"],
-      "allowedVersions": "~5.3.0"
-    },
-    {
-      "matchPackageNames": ["yn"],
-      "allowedVersions": "<5.0.0"
-    },
+    { "matchManagers": ["github-actions"], "groupName": "GitHub Actions" },
+    { "matchPackageNames": ["node-fetch"], "allowedVersions": "<3.0.0" },
+    { "matchPackageNames": ["typescript"], "allowedVersions": "~5.3.0" },
+    { "matchPackageNames": ["yn"], "allowedVersions": "<5.0.0" },
     {
       "description": "all RHDH Plugins workspaces",
       "extends": [
@@ -57,7 +41,8 @@
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-sandbox-presets",
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-openshift-image-registry-presets",
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-redhat-resource-optimization-presets",
-        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-quickstart-presets"
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-quickstart-presets",
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-mcp-integrations-presets"
       ]
     },
     {


### PR DESCRIPTION
This PR adds Renovate presets for the new `mcp-integrations` workspace.

Extends: base minor/patch/devdependency presets.

Created by [Detect New Workspace 18295428523](https://github.com/JessicaJHee/rhdh-plugins/actions/runs/18295428523)