### PR TITLE
chore: add Renovate presets for ai-integrations

### DIFF
--- a/.github/renovate-presets/workspace/rhdh-ai-integrations-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-ai-integrations-presets.json
@@ -1,0 +1,28 @@
+{
+  "packageRules": [
+    {
+      "description": "all Ai Integrations minor updates",
+      "matchFileNames": ["workspaces/ai-integrations/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(Ai Integrations)"
+      ],
+      "addLabels": ["team/rhdh", "ai-integrations"]
+    },
+    {
+      "description": "all Ai Integrations patch updates",
+      "matchFileNames": ["workspaces/ai-integrations/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(Ai Integrations)"
+      ],
+      "addLabels": ["team/rhdh", "ai-integrations"]
+    },
+    {
+      "description": "all Ai Integrations dev dependency updates",
+      "matchFileNames": ["workspaces/ai-integrations/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(Ai Integrations)"
+      ],
+      "addLabels": ["team/rhdh", "ai-integrations"]
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -57,7 +57,8 @@
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-sandbox-presets",
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-openshift-image-registry-presets",
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-redhat-resource-optimization-presets",
-        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-quickstart-presets"
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-quickstart-presets",
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-ai-integrations-presets"
       ]
     },
     {


### PR DESCRIPTION
This PR adds Renovate presets for the new `ai-integrations` workspace.

Extends: base minor/patch/devdependency presets.

Created by [Detect New Workspace 18326173829](https://github.com/JessicaJHee/rhdh-plugins/actions/runs/18326173829)