### PR TITLE
chore: add Renovate presets for global-header

### DIFF
--- a/.github/renovate-presets/workspace/rhdh-global-header-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-global-header-presets.json
@@ -1,0 +1,28 @@
+{
+  "packageRules": [
+    {
+      "description": "all Global Header minor updates",
+      "matchFileNames": ["workspaces/global-header/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(Global Header)"
+      ],
+      "addLabels": ["team/rhdh", "global-header"]
+    },
+    {
+      "description": "all Global Header patch updates",
+      "matchFileNames": ["workspaces/global-header/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(Global Header)"
+      ],
+      "addLabels": ["team/rhdh", "global-header"]
+    },
+    {
+      "description": "all Global Header dev dependency updates",
+      "matchFileNames": ["workspaces/global-header/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(Global Header)"
+      ],
+      "addLabels": ["team/rhdh", "global-header"]
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -57,7 +57,8 @@
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-sandbox-presets",
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-openshift-image-registry-presets",
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-redhat-resource-optimization-presets",
-        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-quickstart-presets"
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-quickstart-presets",
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-global-header-presets"
       ]
     },
     {


### PR DESCRIPTION
This PR adds Renovate presets for the new `global-header` workspace.

Extends: base minor/patch/devdependency presets.

Created by [Detect New Workspace 18326173829](https://github.com/JessicaJHee/rhdh-plugins/actions/runs/18326173829)