### PR TITLE
chore: add Renovate presets for global-floating-action-button

### DIFF
--- a/.github/renovate-presets/workspace/rhdh-global-floating-action-button-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-global-floating-action-button-presets.json
@@ -1,0 +1,28 @@
+{
+  "packageRules": [
+    {
+      "description": "all Global Floating Action Button minor updates",
+      "matchFileNames": ["workspaces/global-floating-action-button/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(Global Floating Action Button)"
+      ],
+      "addLabels": ["team/rhdh", "global-floating-action-button"]
+    },
+    {
+      "description": "all Global Floating Action Button patch updates",
+      "matchFileNames": ["workspaces/global-floating-action-button/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(Global Floating Action Button)"
+      ],
+      "addLabels": ["team/rhdh", "global-floating-action-button"]
+    },
+    {
+      "description": "all Global Floating Action Button dev dependency updates",
+      "matchFileNames": ["workspaces/global-floating-action-button/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(Global Floating Action Button)"
+      ],
+      "addLabels": ["team/rhdh", "global-floating-action-button"]
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -57,7 +57,8 @@
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-sandbox-presets",
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-openshift-image-registry-presets",
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-redhat-resource-optimization-presets",
-        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-quickstart-presets"
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-quickstart-presets",
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-global-floating-action-button-presets"
       ]
     },
     {


### PR DESCRIPTION
This PR adds Renovate presets for the new `global-floating-action-button` workspace.

Extends: base minor/patch/devdependency presets.

Created by [Detect New Workspace 18326173829](https://github.com/JessicaJHee/rhdh-plugins/actions/runs/18326173829)