### PR TITLE
chore: add Renovate presets for translations

### DIFF
--- a/.github/renovate-presets/workspace/rhdh-translations-presets.json
+++ b/.github/renovate-presets/workspace/rhdh-translations-presets.json
@@ -1,0 +1,28 @@
+{
+  "packageRules": [
+    {
+      "description": "all Translations minor updates",
+      "matchFileNames": ["workspaces/translations/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-minor-presets(Translations)"
+      ],
+      "addLabels": ["team/rhdh", "translations"]
+    },
+    {
+      "description": "all Translations patch updates",
+      "matchFileNames": ["workspaces/translations/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-patch-presets(Translations)"
+      ],
+      "addLabels": ["team/rhdh", "translations"]
+    },
+    {
+      "description": "all Translations dev dependency updates",
+      "matchFileNames": ["workspaces/translations/**"],
+      "extends": [
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/base/rhdh-devdependency-presets(Translations)"
+      ],
+      "addLabels": ["team/rhdh", "translations"]
+    }
+  ]
+}

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -57,7 +57,8 @@
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-sandbox-presets",
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-openshift-image-registry-presets",
         "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-redhat-resource-optimization-presets",
-        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-quickstart-presets"
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-quickstart-presets",
+        "github>redhat-developer/rhdh-plugins//.github/renovate-presets/workspace/rhdh-translations-presets"
       ]
     },
     {


### PR DESCRIPTION
This PR adds Renovate presets for the new `translations` workspace.

Extends: base minor/patch/devdependency presets.

Created by [Detect New Workspace 18326173829](https://github.com/JessicaJHee/rhdh-plugins/actions/runs/18326173829)